### PR TITLE
Update download link

### DIFF
--- a/dynamodb/config.json
+++ b/dynamodb/config.json
@@ -1,6 +1,6 @@
 {
   "setup": {
-    "download_url": "https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.tar.gz",
+    "download_url": "https://d1ni2b6xgvw0s0.cloudfront.net/dynamodb_local_2023-06-30.tar.gz",
     "install_path": "bin",
     "jar": "DynamoDBLocal.jar"
   },


### PR DESCRIPTION
AWS updated the docs couple days ago, with the release of DynamoDB Local 1.23.0 and 2.0.0: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.DownloadingAndRunning.html

I updated the download URL to use the new domain, but also to point to a concrete version instead of `latest` (found the filename [here](https://d1ni2b6xgvw0s0.cloudfront.net)). I think it's better to have it fixed to avoid surprise automatic updates in the future.

Changing the link to v2  https://d1ni2b6xgvw0s0.cloudfront.net/v2.x/dynamodb_local_2023-06-28.tar.gz could also be considered, but maybe as a breaking release