### PR TITLE
Use CloudFront URL

### DIFF
--- a/dynamodb/config.json
+++ b/dynamodb/config.json
@@ -1,6 +1,6 @@
 {
   "setup": {
-    "download_url": "https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.tar.gz",
+    "download_url": "https://d1ni2b6xgvw0s0.cloudfront.net/dynamodb_local_latest.tar.gz",
     "install_path": "bin",
     "jar": "DynamoDBLocal.jar"
   },


### PR DESCRIPTION
This is the AWS-promoted route, and downloads faster for most users.